### PR TITLE
Implement covariance over slots

### DIFF
--- a/pytorch/model.py
+++ b/pytorch/model.py
@@ -325,9 +325,8 @@ class ProjectionHead(nn.Module):
             # `std` has shape: [proj_dim].
             # cov. over slots shape: [num_slots].
 
-        out = {"std_loss": std_loss, "cov_loss": cov_loss, 'proj_batch_sz': proj_batch_sz}
-        if self.cov_over_slots:
-            out['proj_mean'] = torch.mean(proj_mean).item()
+        out = {"std_loss": std_loss, "cov_loss": cov_loss, 'proj_mean': torch.mean(proj_mean).item(),
+               'proj_batch_sz': proj_batch_sz}
 
         if self.vis:
             out['cov_mx'] = cov.detach().cpu()

--- a/pytorch/train.py
+++ b/pytorch/train.py
@@ -99,9 +99,9 @@ def main(opt):
                 vis_dict['slot_sample_mean'] = torch.mean(model.slot_attention.slots_mu).item()
                 vis_dict['slot_sample_std'] = torch.mean(model.slot_attention.slots_sigma).item()
 
-                # Visualize the mean of the per-dimension means of slot projections
-                if not opt.slot_cov:
-                    vis_dict['avg_proj_dim_mean'] = proj_loss_dict['proj_mean']
+                # Visualize the mean of the per-dimension means of slot projections 
+                # (mean of per-slot means for covariance over slots setting)
+                vis_dict['avg_proj_dim_mean'] = proj_loss_dict['proj_mean']
 
                 # Visualize influence of reconstruction loss vs. projection head losses
                 # Positive if reconstruction loss dominates loss, negative if projection losses dominate
@@ -178,7 +178,10 @@ def visualize(vis_dict, opt, image, recon_combined, recons, masks, slots, proj_l
         plt.close()
 
         plt.figure(figsize=(10,10))
-        plt.imshow(proj_loss_dict['std_vec'].flatten().unsqueeze(1).repeat((1, 50)), cmap='Blues')
+        if opt.slot_cov:
+            plt.imshow(proj_loss_dict['std_vec'].flatten().unsqueeze(1).repeat((1, 50)), cmap='Blues')
+        else:
+            plt.imshow(proj_loss_dict['std_vec'].unsqueeze(1).repeat((1, 50)), cmap='Blues')
         plt.colorbar()
         vis_dict['std'] = wandb.Image(plt)
         plt.close()


### PR DESCRIPTION
Implements covariance over slots by calculating the covariance loss over the slots for each image in a batch separately and then taking the average over all images in the batch. 

The standard deviation loss is also calculated over slots for each image individually and then averaged over all images in the batch. It is questionable if this std. loss is actually meaningful/helpful for this covariance over slots setting, but we can always set the std. target to 0 to remove this loss term.