### PR TITLE
add identity projection option

### DIFF
--- a/pytorch/model.py
+++ b/pytorch/model.py
@@ -256,15 +256,19 @@ class ProjectionHead(nn.Module):
             self.cov_div = self.proj_dim
 
         # VICReg paper, Section 4.2. Two FC layers with non-linearities and a final linear layer
-        self.projector = nn.Sequential(
-            nn.Linear(opt.hid_dim, opt.proj_dim),
-            nn.BatchNorm1d(opt.num_slots),
-            nn.ReLU(),
-            nn.Linear(opt.proj_dim, opt.proj_dim),
-            nn.BatchNorm1d(opt.num_slots),
-            nn.ReLU(),
-            nn.Linear(opt.proj_dim, opt.proj_dim)
-        )
+        if not opt.identity_proj:
+            self.projector = nn.Sequential(
+                nn.Linear(opt.hid_dim, opt.proj_dim),
+                nn.BatchNorm1d(opt.num_slots),
+                nn.ReLU(),
+                nn.Linear(opt.proj_dim, opt.proj_dim),
+                nn.BatchNorm1d(opt.num_slots),
+                nn.ReLU(),
+                nn.Linear(opt.proj_dim, opt.proj_dim)
+            )
+        else:
+            assert opt.hid_dim == opt.proj_dim, "Identity projection requires hidden dimension size = projection dimention size"
+            self.projector = nn.Identity()
 
 
     def forward(self, x, vis_step):

--- a/pytorch/train.py
+++ b/pytorch/train.py
@@ -256,6 +256,7 @@ if __name__ == "__main__":
     parser.add_argument('--cov-div-sq', action='store_true', help='divide projection head covariance by the square of the number of projection dimensions')
     parser.add_argument('--slot-cov', action='store_true', help='calculate covariance over slots rather than over projection feature dimension')
     parser.add_argument('--bce-loss', action='store_true', help='calculate the reconstruction loss using binary cross entropy rather than mean squared error')
+    parser.add_argument('--identity-proj', action='store_true', help='set projection to identity function. This option is equivalent to applying var/cov regularization on slot vectors directly')
 
 
     main(parser.parse_args())


### PR DESCRIPTION
* Add `--identity_proj` option for baseline mentioned in https://github.com/robert1003/slot-attention-pytorch/issues/17
* This option will replace the projection head to an identity function.