### PR TITLE
Add layernorm to projection layer

### DIFF
--- a/pytorch/model.py
+++ b/pytorch/model.py
@@ -297,15 +297,19 @@ class ProjectionHead(nn.Module):
             self.cov_div = self.proj_dim
 
         # VICReg paper, Section 4.2. Two FC layers with non-linearities and a final linear layer
-        norm_layer = nn.LayerNorm if opt.proj_layernorm else nn.BatchNorm1d
+        norm_layer = None
+        if opt.proj_layernorm:
+            norm_layer = lambda: nn.LayerNorm(opt.proj_dim)
+        else:
+            norm_layer = lambda: nn.BatchNorm1d(opt.num_slots)
 
         if not opt.identity_proj:
             self.projector = nn.Sequential(
                 nn.Linear(opt.hid_dim, opt.proj_dim),
-                norm_layer(opt.num_slots),
+                norm_layer(),
                 nn.ReLU(),
                 nn.Linear(opt.proj_dim, opt.proj_dim),
-                norm_layer(opt.num_slots),
+                norm_layer(),
                 nn.ReLU(),
                 nn.Linear(opt.proj_dim, opt.proj_dim)
             )

--- a/pytorch/train.py
+++ b/pytorch/train.py
@@ -287,7 +287,7 @@ if __name__ == "__main__":
     parser.add_argument('--bce-loss', action='store_true', help='calculate the reconstruction loss using binary cross entropy rather than mean squared error')
     parser.add_argument('--identity-proj', action='store_true', help='set projection to identity function. This option is equivalent to applying var/cov regularization on slot vectors directly')
     parser.add_argument('--dataset-rescale', action='store_true', help='by default image is rescaled from [0,255] to [0,1]. This option enables rescale from [0,255] to [-1,1]. This option the one used in original Slot Attention paper')
-    parser.add_arugment('--proj-layernorm', action='store_true', help='use layernorm in projection layer (default is batchnorm)')
+    parser.add_argument('--proj-layernorm', action='store_true', help='use layernorm in projection layer (default is batchnorm)')
 
     main(parser.parse_args())
 


### PR DESCRIPTION
* Add a switch for layernorm in projection layer

Note that for batchnorm, we normalize over slots: 
  sample has shape (N, num_slots, proj_dim), mean is calculated over N
for layernorm, we normalize over features:
  sample has shape (N, num_slots, proj_dim), mean is calculated over proj_dim