### PR TITLE
cosine similarity fix: change to official implementation

### DIFF
--- a/pytorch/model.py
+++ b/pytorch/model.py
@@ -291,7 +291,6 @@ class ProjectionHead(nn.Module):
         self.vis = vis
         self.cov_over_slots = opt.slot_cov
         self.info_nce = opt.info_nce
-        self.temperature = opt.temperature
 
         if opt.cov_div_sq:
             self.cov_div = self.proj_dim**2
@@ -331,19 +330,20 @@ class ProjectionHead(nn.Module):
 
         
         if self.info_nce:
-            # formula: log (\sum_k, k != i exp(<z_i, z_k> / norm(z_i) / norm(z_k) / temperature))
-            norm = projection.norm(dim=2, keepdim=True)
-            cosine_similarity = torch.matmul(projection, projection.permute(0, 2, 1)) / norm / norm.permute(0, 2, 1)
-            cosine_similarity /= self.temperature
-            # `cosine_similarity` has shape: [batch_size, num_slots, num_slots]
+            batch_size, num_slots, proj_dim = projection.shape
+            projection = projection.repeat(1, num_slots, 1)
+            # `projection` has shape: [batch_size, num_slots*num_slots, proj_dim]
+            target = -torch.ones(num_slots*num_slots).to(device)
+            for i in range(num_slots):
+                target[num_slots*i+i] = 1
+            # `target` has shape: [num_slots*num_slots,]
 
-            # set diagonal to -inf since we need to exclude self similarity calculation
-            batch_size = cosine_similarity.shape[0]
-            num_slots = cosine_similarity.shape[1]
-            mask = torch.eye(num_slots).repeat(batch_size, 1, 1).bool()
-            cosine_similarity[mask] = -1e9
-            info_nce_loss = torch.logsumexp(cosine_similarity, dim=(1,2)) / (num_slots**2)
-            info_nce_loss = torch.mean(info_nce_loss)
+            projection = projection.view(-1, proj_dim)
+            # `projection` has shape: [batch_size*num_slots*num_slots, proj_dim]
+            target = target.repeat(batch_size)
+            # `target` has shape: [batch_size*num_slots*num_slots,]
+
+            info_nce_loss = torch.nn.functional.cosine_embedding_loss(projection, projection, target)
         elif self.cov_over_slots:
             # Calculate covariance over slots loss for each image separately, then take average. Same for std loss.
             # Take mean over feature dimension for each slot of each batch (separately)

--- a/pytorch/train.py
+++ b/pytorch/train.py
@@ -300,7 +300,6 @@ if __name__ == "__main__":
     parser.add_argument('--cov-div-sq', action='store_true', help='divide projection head covariance by the square of the number of projection dimensions')
     parser.add_argument('--slot-cov', action='store_true', help='calculate covariance over slots rather than over projection feature dimension')
     parser.add_argument('--info-nce', action='store_true', help='use InfoNCE style loss instead of cov loss')
-    parser.add_argument('--temperature', default=0.1, type=float, help='temperature used for info-nce loss')
     parser.add_argument('--info-nce-weight', default=0.1, type=float, help='weight given to the info nce loss')
     parser.add_argument('--info-nce-warmup', default=5000, type=float, help='number of warup steps for the infonce loss')
     parser.add_argument('--cov-warmup', default=0, type=int, help='number of warmup steps for the covariance loss')


### PR DESCRIPTION
* Replace the original implementation with pytorch implementation. The original implementation is buggy since it is minimizing <z_i, z_j> instead of abs(<z_i, z_j>). In the actual training we observed that it collapsed.